### PR TITLE
Add Waveform Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tweakpane essentials plugin
 Essential components for [Tweakpane][tweakpane].
 
-![](https://user-images.githubusercontent.com/602961/122059107-41ec8c80-ce27-11eb-9d17-08c522efb05f.png)
+![plugin- essentials](https://user-images.githubusercontent.com/38029550/200204309-76ce8fd4-31a6-487d-b87f-0e868eda7a52.png)
 
 
 ## Installation
@@ -133,6 +133,7 @@ pane.addBlade({
 ```
 
 ### Waveform
+![waveform](https://user-images.githubusercontent.com/38029550/200204325-734b04af-9b4a-4a53-972e-f3b1eabdd9a1.png)
 
 ```js
 const params = {

--- a/README.md
+++ b/README.md
@@ -132,5 +132,29 @@ pane.addBlade({
 });
 ```
 
+### Waveform
+
+```js
+const params = {
+  prop1: [ 5, 6, 7, 8, 9, 3, 9, 8, 7, 6, 5 ],
+  prop2: new Uint8Array(8).fill(0).map((_, i) => Math.pow(2, i+1) - 1),
+};
+
+pane.addMonitor(params, 'prop1', {
+  view: 'waveform',
+  min: 0,
+  max: 10,
+  style: 'bezier',
+  interval: 100,
+})
+
+pane.addMonitor(params, 'prop2', {
+  view: 'waveform',
+  min: 0,
+  max: Math.pow(2, 8),
+  interval: 500
+})
+```
+
 
 [tweakpane]: https://github.com/cocopon/tweakpane/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tweakpane/plugin-essentials",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Essential components for Tweakpane",
   "main": "dist/tweakpane-plugin-essentials.js",
   "types": "dist/types/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {CubicBezierBladePlugin} from './cubic-bezier/plugin';
 import {FpsGraphBladePlugin} from './fps-graph/plugin';
 import {IntervalInputPlugin} from './interval/plugin';
 import {RadioGridBladePlugin} from './radio-grid/blade-plugin';
+import { WaveformPlugin } from './waveform/plugin';
 import {
 	RadioGruidBooleanInputPlugin,
 	RadioGruidNumberInputPlugin,
@@ -22,4 +23,5 @@ export const plugins: TpPlugin[] = [
 	RadioGruidBooleanInputPlugin,
 	RadioGruidNumberInputPlugin,
 	RadioGruidStringInputPlugin,
+	WaveformPlugin
 ];

--- a/src/sass/_waveform.scss
+++ b/src/sass/_waveform.scss
@@ -1,0 +1,47 @@
+.#{$prefix}-wfmv {
+	position: relative;
+
+	background-image: linear-gradient(
+			to right,
+			var(--cnt-bg),
+			1px,
+			transparent 1px
+		),
+		linear-gradient(to bottom, var(--cnt-bg), 1px, transparent 1px);
+
+	&_g {
+		@extend %monitor;
+
+		display: block;
+		height: calc(var(--bld-us) * 3);
+
+		path {
+			fill: none;
+			stroke: var(--mo-fg);
+			stroke-linejoin: round;
+		}
+	}
+	&_t {
+		margin-top: -4px;
+		transition: left 0.05s, top 0.05s;
+		visibility: hidden;
+
+		&#{&}-a {
+			visibility: visible;
+		}
+		&#{&}-in {
+			transition: none;
+		}
+	}
+	&.#{$prefix}-v-disabled &_g {
+		opacity: 0.5;
+	}
+
+	.#{$prefix}-ttv {
+		background-color: var(--mo-fg);
+
+		&::before {
+			border-top-color: var(--mo-fg);
+		}
+	}
+}

--- a/src/sass/plugin.scss
+++ b/src/sass/plugin.scss
@@ -7,3 +7,4 @@
 @import './interval';
 @import './radio';
 @import './radio-grid';
+@import './waveform';

--- a/src/waveform/controller/waveform.ts
+++ b/src/waveform/controller/waveform.ts
@@ -20,7 +20,7 @@ export class WaveformController implements Controller<WaveformView> {
 		this.props = config.props;
 		this.viewProps = config.viewProps;
 		this.viewProps.handleDispose(() => {
-			console.error('TODO: dispose controller');
+			// Nothing to do
 		});
 
 		this.view = new WaveformView(doc, {

--- a/src/waveform/controller/waveform.ts
+++ b/src/waveform/controller/waveform.ts
@@ -1,0 +1,32 @@
+import {BufferedValue, Controller, ViewProps} from '@tweakpane/core';
+
+import {WaveformProps, WaveformValue, WaveformView} from '../view/waveform';
+
+interface Config {
+	value: BufferedValue<WaveformValue>;
+	viewProps: ViewProps;
+	props: WaveformProps;
+}
+
+// Custom controller class should implement `Controller` interface
+export class WaveformController implements Controller<WaveformView> {
+	public readonly value: BufferedValue<WaveformValue>;
+	public readonly view: WaveformView;
+	public readonly viewProps: ViewProps;
+	private readonly props: WaveformProps;
+
+	constructor(doc: Document, config: Config) {
+		this.value = config.value;
+		this.props = config.props;
+		this.viewProps = config.viewProps;
+		this.viewProps.handleDispose(() => {
+			console.error('TODO: dispose controller');
+		});
+
+		this.view = new WaveformView(doc, {
+			value: this.value,
+			viewProps: this.viewProps,
+			props: this.props,
+		});
+	}
+}

--- a/src/waveform/plugin.ts
+++ b/src/waveform/plugin.ts
@@ -1,0 +1,78 @@
+import {
+	BaseMonitorParams,
+	Controller,
+	MonitorBindingPlugin,
+	ParamsParsers,
+	parseParams,
+	ValueMap,
+	View,
+} from '@tweakpane/core';
+import {BindingReader} from '@tweakpane/core/dist/cjs/common/binding/binding';
+
+import {WaveformController} from './controller/waveform';
+import {WaveformStyles, WaveformValue} from './view/waveform';
+
+export interface WaveformMonitorParams extends BaseMonitorParams {
+	max?: number;
+	min?: number;
+	style?: WaveformStyles;
+}
+
+function shouldShowWaveform(params: WaveformMonitorParams): boolean {
+	return 'view' in params && params.view === 'waveform';
+}
+
+function isWaveformType(value: unknown): value is WaveformValue & boolean {
+	if (typeof value === 'object') {
+		return 'length' in (value as Record<string, unknown>);
+	}
+	return false;
+}
+
+export const WaveformPlugin: MonitorBindingPlugin<
+	WaveformValue,
+	WaveformMonitorParams
+> = {
+	id: 'monitor-waveform',
+	type: 'monitor',
+	css: '__css__',
+
+	accept: (value, params) => {
+		if (!isWaveformType(value)) {
+			return null;
+		}
+		const p = ParamsParsers;
+		const result = parseParams<WaveformMonitorParams>(params, {
+			max: p.optional.number,
+			min: p.optional.number,
+			style: p.optional.custom<WaveformStyles>((value) =>
+				value === 'linear' || value === 'bezier' ? value : undefined,
+			),
+			view: p.optional.string,
+		});
+		return result ? {initialValue: value, params: result} : null;
+	},
+	binding: {
+		defaultBufferSize: (params) => (shouldShowWaveform(params) ? 64 : 1),
+		reader:
+			(_args): BindingReader<WaveformValue> =>
+			(exValue: unknown): WaveformValue => {
+				if (isWaveformType(exValue)) {
+					return exValue as WaveformValue;
+				}
+				return [];
+			},
+	},
+	controller: (args) => {
+		return new WaveformController(args.document, {
+			props: ValueMap.fromObject({
+				maxValue: ('max' in args.params ? args.params.max : null) ?? 100,
+				minValue: ('min' in args.params ? args.params.min : null) ?? 0,
+				lineStyle:
+					('style' in args.params ? args.params.style : null) ?? 'linear',
+			}),
+			value: args.value,
+			viewProps: args.viewProps,
+		});
+	},
+};

--- a/src/waveform/view/waveform-drawer.ts
+++ b/src/waveform/view/waveform-drawer.ts
@@ -1,0 +1,57 @@
+import {IWaveformDrawerProvider, WaveformPoint} from './waveform';
+
+export class LinearDrawerProvider implements IWaveformDrawerProvider {
+	public readonly drawer = (point: WaveformPoint): string =>
+		`L ${point[0]} ${point[1]}`;
+}
+
+export class CubicBézierDrawerProvider implements IWaveformDrawerProvider {
+	private controlPoint(
+		current: WaveformPoint,
+		previous: WaveformPoint,
+		next: WaveformPoint,
+		reverse?: boolean,
+	): WaveformPoint {
+		// When 'current' is the first or last point of the array  'previous' or 'next' don't exist. Replace with 'current'
+		const a = previous || current;
+		const b = next || current;
+
+		// The smoothing ratio
+		const smoothing = 0.2;
+
+		// Properties of the opposed-line
+		const lenX = b[0] - a[0];
+		const lenY = b[1] - a[1];
+
+		// If is end-control-point, add PI to the angle to go backward
+		const length = Math.sqrt(Math.pow(lenX, 2) + Math.pow(lenY, 2)) * smoothing;
+		const angle = Math.atan2(lenY, lenX) + (reverse ? Math.PI : 0);
+
+		// The control point position is relative to the current point
+		const x = current[0] + Math.cos(angle) * length;
+		const y = current[1] + Math.sin(angle) * length;
+
+		return [x, y];
+	}
+
+	public readonly drawer = (
+		point: WaveformPoint,
+		index: number,
+		points: WaveformPoint[],
+	): string => {
+		// start control point
+		const [cpsX, cpsY] = this.controlPoint(
+			points[index - 1],
+			points[index - 2],
+			point,
+		);
+		// end control point
+		const [cpeX, cpeY] = this.controlPoint(
+			point,
+			points[index - 1],
+			points[index + 1],
+			true,
+		);
+		return `C ${cpsX},${cpsY} ${cpeX},${cpeY} ${point[0]},${point[1]}`;
+	};
+}

--- a/src/waveform/view/waveform.ts
+++ b/src/waveform/view/waveform.ts
@@ -1,0 +1,136 @@
+import {
+	BufferedValue,
+	ClassName,
+	mapRange,
+	SVG_NS,
+	ValueMap,
+	View,
+	ViewProps,
+} from '@tweakpane/core';
+
+import {
+	CubicBézierDrawerProvider,
+	LinearDrawerProvider,
+} from './waveform-drawer';
+
+export type WaveformValue = Uint8Array | Uint16Array | Uint32Array | number[];
+
+export type WaveformStyles = 'linear' | 'bezier';
+
+export type WaveformProps = ValueMap<{
+	maxValue: number;
+	minValue: number;
+	lineStyle: WaveformStyles;
+}>;
+
+export type WaveformPoint = [number, number];
+
+type WaveformDrawer = (
+	point: WaveformPoint,
+	index: number,
+	points: WaveformPoint[],
+) => string;
+
+export interface IWaveformDrawerProvider {
+	readonly drawer: WaveformDrawer;
+}
+
+interface Config {
+	value: BufferedValue<WaveformValue>;
+	viewProps: ViewProps;
+	props: WaveformProps;
+}
+
+const className = ClassName('wfm');
+
+/**
+ * @hidden
+ */
+export class WaveformView implements View {
+	public readonly element: HTMLElement;
+	private readonly props: WaveformProps;
+	private readonly value: BufferedValue<WaveformValue>;
+	private readonly svgElem: SVGElement;
+	private readonly pathElem: SVGPathElement;
+	private readonly lineDrawProvider: IWaveformDrawerProvider;
+
+	constructor(doc: Document, config: Config) {
+		this.element = doc.createElement('div');
+		this.element.classList.add(className());
+		config.viewProps.bindClassModifiers(this.element);
+
+		this.svgElem = doc.createElementNS(SVG_NS, 'svg');
+		this.svgElem.classList.add(className('g'));
+		this.element.appendChild(this.svgElem);
+
+		this.pathElem = doc.createElementNS(SVG_NS, 'path');
+		this.svgElem.appendChild(this.pathElem);
+
+		this.props = config.props;
+		this.value = config.value;
+		this.value.emitter.on('change', this.onValueChange_.bind(this));
+
+		switch (this.props.get('lineStyle')) {
+			case 'linear':
+				this.lineDrawProvider = new LinearDrawerProvider();
+				break;
+			case 'bezier':
+				this.lineDrawProvider = new CubicBézierDrawerProvider();
+				break;
+			default:
+				this.lineDrawProvider = new LinearDrawerProvider();
+				break;
+		}
+
+		this.refresh();
+
+		config.viewProps.handleDispose(() => {
+			this.value.emitter.off('change', this.onValueChange_);
+		});
+	}
+
+	private svgPath(points: WaveformPoint[], drawer: WaveformDrawer) {
+		const d = points.reduce(
+			(acc, point, i, a) =>
+				i === 0 ? `M ${point[0]},${point[1]}` : `${acc} ${drawer(point, i, a)}`,
+			'',
+		);
+		return d;
+	}
+
+	private refresh(): void {
+		const bounds = this.svgElem.getBoundingClientRect();
+		const latestValue = this.value.rawValue[this.value.rawValue.length - 1];
+
+		// Graph
+		const min = this.props.get('minValue');
+		const max = this.props.get('maxValue');
+		const range = max - min;
+		const points: WaveformPoint[] = [];
+
+		if (latestValue) {
+			const maxIndex = latestValue.length - 1;
+
+			// Grid
+			const gridWidth =
+				latestValue.length > 32 ? 0 : bounds.width / (latestValue.length - 1);
+			const gridHeight = range > 50 ? 0 : bounds.height / range;
+			this.element.style.backgroundSize = `${gridWidth}px ${gridHeight}px`;
+
+			latestValue.forEach((v, index) => {
+				if (v === undefined) {
+					return;
+				}
+				const x = mapRange(index, 0, maxIndex, 0, bounds.width);
+				const y = mapRange(v, min, max, bounds.height, 0);
+				points.push([Math.floor(x), Math.floor(y)]);
+			});
+			const d = this.svgPath(points, this.lineDrawProvider.drawer);
+			this.pathElem.setAttributeNS(null, 'd', d);
+		}
+	}
+
+	private onValueChange_() {
+		this.refresh();
+	}
+}

--- a/test/browser.html
+++ b/test/browser.html
@@ -29,13 +29,44 @@
 	<script src="../node_modules/tweakpane/dist/tweakpane.js"></script>
 	<script src="../dist/tweakpane-plugin-essentials.js"></script>
 	<script>
+		window.ctx = new AudioContext();
+		window.anl = ctx.createAnalyser();
+		window.osc = null;
+
+		anl.connect(ctx.destination);
+		anl.fftSize = 2048;
+
 		const params = {
 			interval: {min: 40, max: 60},
 			radiogrid: 25,
+			smallNumberArray: [ 5, 6, 7, 8, 9, 3, 9, 8, 7, 6, 5 ],
+			uint8Array: new Uint8Array(8).fill(0).map((_, i) => Math.pow(2, i+1) - 1),
+			uint16Array: new Uint16Array(16).fill(0).map((_, i) => Math.pow(2, i+1) - 1),
+			uint32Array: new Uint32Array(32).fill(0).map((_, i) => Math.pow(2, i+1) - 1),
+			webAudioApiAnlBuf: new Uint8Array(anl.frequencyBinCount)
 		};
+
+		setInterval(() => {
+			if (osc)
+				osc.frequency.value = osc.frequency.value > 100 ? 40 : osc.frequency.value + 1;
+		}, 500);
+		
+		setInterval(() => {
+			anl.getByteTimeDomainData(params.webAudioApiAnlBuf);
+			panes[2].refresh();
+		}, 1);
+
+		setInterval(() => {
+			params.smallNumberArray = params.smallNumberArray.map(v => Math.max(0, Math.min(10, v + (Math.random() * 2 - 1) * 0.1)) );
+			params.uint8Array = params.uint8Array.map(v => ++v );
+			params.uint16Array = params.uint16Array.map(v => v+1e2 );
+			params.uint32Array = params.uint32Array.map(v => v+1e8 );
+		}, 50);
+
 		const panes = [
 			'Input bindings',
 			'Blades',
+			'Monitors'
 		].map((title) => {
 			const pane = new Tweakpane.Pane({
 				container: document.querySelector('.wrapper'),
@@ -113,6 +144,58 @@
 		}).on('click', (ev) => {
 			console.log(ev);
 		});
+
+		// Monitors
+		panes[2].addMonitor(params, 'smallNumberArray', {
+			view: 'waveform',
+			min: 0,
+			max: 10,
+			interval: 100
+		})
+
+		panes[2].addMonitor(params, 'uint8Array', {
+			view: 'waveform',
+			min: 0,
+			max: Math.pow(2, 8),
+			interval: 500
+		})
+
+		panes[2].addMonitor(params, 'uint16Array', {
+			view: 'waveform',
+			min: 0,
+			max: Math.pow(2, 16),
+			interval: 500
+		})
+
+		panes[2].addMonitor(params, 'uint32Array', {
+			view: 'waveform',
+			min: 0,
+			max: Math.pow(2, 32),
+			interval: 500,
+			style: 'bezier'
+		})
+
+		panes[2].addMonitor(params, 'webAudioApiAnlBuf', {
+			view: 'waveform',
+			min: -50,
+			max: Math.pow(2, 8) + 50,
+			interval: 0,
+		})
+
+		const audioToggleBtn = panes[2].addButton({ 
+      title: "Start Web Audio API" 
+    }).on("click", () => { 
+			if (osc) {
+				osc.stop();
+				osc = null;
+				audioToggleBtn.title = 'Start Web Audio API';
+			} else {
+				osc = ctx.createOscillator();
+				osc.connect(anl);
+				osc.start();
+				audioToggleBtn.title = 'Stop Web Audio API';
+			}
+    });
 
 		window.panes = panes;
 


### PR DESCRIPTION
Adds a simple Waveform Monitor which is useful for monitoring arrays.
I mainly wanted to have this ability to view data from the Web Audio API's Analysers. It also works for other kinds of Arrays / Buffers. See type `WaveformValue`

Note that I'm having issues with the tweakpane fonts when developing locally on my machine (See changed images in README, all fonts are changed to a generic monospaced one).
I've still changed the affected images in the README - I do need a pointer on how to fix this and update the images before merging. (Maybe I'm missing a Font on my machine?)
