### PR TITLE
Fix SVG scaling in Cubic Bezier.

### DIFF
--- a/src/cubic-bezier/view/cubic-bezier-graph.ts
+++ b/src/cubic-bezier/view/cubic-bezier-graph.ts
@@ -105,9 +105,7 @@ export class CubicBezierGraphView implements View {
 	}
 
 	public valueToPosition(x: number, y: number): {x: number; y: number} {
-		const bounds = this.element.getBoundingClientRect();
-		const w = bounds.width;
-		const h = bounds.height;
+		const {clientWidth: w, clientHeight: h} = this.element;
 		const vm = this.getVertMargin_(h);
 		return {
 			x: mapRange(x, 0, 1, 0, w),

--- a/src/cubic-bezier/view/cubic-bezier-preview.ts
+++ b/src/cubic-bezier/view/cubic-bezier-preview.ts
@@ -89,9 +89,7 @@ export class CubicBezierPreviewView implements View {
 	}
 
 	public refresh(): void {
-		const bounds = this.svgElem_.getBoundingClientRect();
-		const w = bounds.width;
-		const h = bounds.height;
+		const {clientWidth: w, clientHeight: h} = this.svgElem_;
 		const ds: string[] = [];
 		const bezier = this.value_.rawValue;
 		for (let i = 0; i < TICK_COUNT; i++) {


### PR DESCRIPTION
Use `clientWidth` / `clientHeigh` instead of `getBoundingClientRect` in the Cubic Bezier view to support scaling the control with CSS transforms.

Related to [Issue #584](https://github.com/cocopon/tweakpane/issues/584) and [PR #586](https://github.com/cocopon/tweakpane/pull/586)  in the main Tweakpane repository.