### PR TITLE
Avoid Date object creation.

### DIFF
--- a/src/cubic-bezier/view/cubic-bezier-preview.ts
+++ b/src/cubic-bezier/view/cubic-bezier-preview.ts
@@ -69,7 +69,7 @@ export class CubicBezierPreviewView implements View {
 		this.updateMarker_(0);
 		this.markerElem_.classList.add(className('m', 'a'));
 
-		this.startTime_ = new Date().getTime() + PREVIEW_DELAY;
+		this.startTime_ = Date.now() + PREVIEW_DELAY;
 		this.stopped_ = false;
 		requestAnimationFrame(this.onTimer_);
 	}
@@ -105,7 +105,7 @@ export class CubicBezierPreviewView implements View {
 			return;
 		}
 
-		const dt = new Date().getTime() - this.startTime_;
+		const dt = Date.now() - this.startTime_;
 		const p = dt / PREVIEW_DURATION;
 		this.updateMarker_(p);
 

--- a/src/fps-graph/controller/fps-graph.ts
+++ b/src/fps-graph/controller/fps-graph.ts
@@ -64,11 +64,11 @@ export class FpsGraphController implements Controller<FpsView> {
 	}
 
 	public begin(): void {
-		this.stopwatch_.begin(new Date());
+		this.stopwatch_.begin(Date.now());
 	}
 
 	public end(): void {
-		this.stopwatch_.end(new Date());
+		this.stopwatch_.end(Date.now());
 	}
 
 	private onTick_(): void {

--- a/src/fps-graph/model/stopwatch.ts
+++ b/src/fps-graph/model/stopwatch.ts
@@ -20,8 +20,8 @@ export class Fpswatch {
 		return this.fps_;
 	}
 
-	public begin(now: Date): void {
-		this.start_ = now.getTime();
+	public begin(now: number): void {
+		this.start_ = now;
 	}
 
 	private calculateFps_(nowTime: number): number | null {
@@ -48,12 +48,12 @@ export class Fpswatch {
 		this.frameCount_ -= df;
 	}
 
-	public end(now: Date): void {
+	public end(now: number): void {
 		if (this.start_ === null) {
 			return;
 		}
 
-		const t = now.getTime();
+		const t = now;
 		this.duration_ = t - this.start_;
 		this.start_ = null;
 


### PR DESCRIPTION
Very minor (20–30%) performance improvements by avoiding `new Date()` in `fps-graph.ts` and `cubic-bezier-preview.ts`.

```js
const iterations = 10_000_000;

console.time("new Date().getTime()");
for (let i = 0; i < iterations; i++) {
  const t = new Date().getTime();
}
console.timeEnd("new Date().getTime()");

console.time("Date.now()");
for (let i = 0; i < iterations; i++) {
  const t = Date.now();
}
console.timeEnd("Date.now()");

// new Date().getTime(): 399.740966796875 ms
// Date.now(): 276.43994140625 ms
```

Just noticed it while working on #21.