### PR TITLE
Feat: element picker

### DIFF
--- a/src/element-picker/api/element-picker.ts
+++ b/src/element-picker/api/element-picker.ts
@@ -35,13 +35,6 @@ export class ElementPickerApi extends BladeApi<ElementPickerBladeController> {
 		});
 	}
 
-	public cell(x: number, y: number): ButtonCellApi | undefined {
-		const vc = this.controller.valueController;
-		const row = vc.rowControllers[y];
-		const cc = row?.cellControllers[x];
-		return cc ? this.cellToApiMap_.get(cc) : undefined;
-	}
-
 	public on<EventName extends keyof ElementPickerApiEvents>(
 		eventName: EventName,
 		handler: (ev: ElementPickerApiEvents[EventName]['event']) => void,

--- a/src/element-picker/api/element-picker.ts
+++ b/src/element-picker/api/element-picker.ts
@@ -1,0 +1,55 @@
+import {BladeApi, ButtonController, Emitter} from '@tweakpane/core';
+
+import {ButtonCellApi} from '../../button-grid/api/button-cell.js';
+import {TpButtonGridEvent} from '../../button-grid/api/tp-button-grid-event.js';
+import {ElementPickerBladeController} from '../controller/element-picker-blade.js';
+
+interface ElementPickerApiEvents {
+	click: {
+		event: TpButtonGridEvent;
+	};
+}
+
+export class ElementPickerApi extends BladeApi<ElementPickerBladeController> {
+	private emitter_: Emitter<ElementPickerApiEvents>;
+	private cellToApiMap_: Map<ButtonController, ButtonCellApi> = new Map();
+
+	constructor(controller: ElementPickerBladeController) {
+		super(controller);
+
+		this.emitter_ = new Emitter();
+
+		const vc = controller.valueController;
+		vc.cellControllers.forEach((cc) => {
+			const api = new ButtonCellApi(cc);
+			this.cellToApiMap_.set(cc, api);
+			cc.emitter.on('click', () => {
+				const coord = vc.cellCoord(cc);
+				if (!coord) {
+					return;
+				}
+				this.emitter_.emit('click', {
+					event: new TpButtonGridEvent(this, api, coord),
+				});
+			});
+		});
+	}
+
+	public cell(x: number, y: number): ButtonCellApi | undefined {
+		const vc = this.controller.valueController;
+		const row = vc.rowControllers[y];
+		const cc = row?.cellControllers[x];
+		return cc ? this.cellToApiMap_.get(cc) : undefined;
+	}
+
+	public on<EventName extends keyof ElementPickerApiEvents>(
+		eventName: EventName,
+		handler: (ev: ElementPickerApiEvents[EventName]['event']) => void,
+	): this {
+		const bh = handler.bind(this);
+		this.emitter_.on(eventName, (ev) => {
+			bh(ev.event);
+		});
+		return this;
+	}
+}

--- a/src/element-picker/controller/element-picker-blade.ts
+++ b/src/element-picker/controller/element-picker-blade.ts
@@ -1,0 +1,37 @@
+import {
+	Blade,
+	BladeController,
+	LabelController,
+	LabelProps,
+	LabelView,
+} from '@tweakpane/core';
+
+import {ElementPickerController} from './element-picker.js';
+
+interface Config {
+	blade: Blade;
+	labelProps: LabelProps;
+	valueController: ElementPickerController;
+}
+
+export class ElementPickerBladeController extends BladeController<LabelView> {
+	public readonly labelController: LabelController<ElementPickerController>;
+	public readonly valueController: ElementPickerController;
+
+	constructor(doc: Document, config: Config) {
+		const vc = config.valueController;
+		const lc = new LabelController(doc, {
+			blade: config.blade,
+			props: config.labelProps,
+			valueController: vc,
+		});
+		super({
+			blade: config.blade,
+			view: lc.view,
+			viewProps: vc.viewProps,
+		});
+
+		this.valueController = vc;
+		this.labelController = lc;
+	}
+}

--- a/src/element-picker/controller/element-picker.ts
+++ b/src/element-picker/controller/element-picker.ts
@@ -25,13 +25,31 @@ export class ElementPickerController implements Controller<PlainView> {
 			viewName: 'elpick',
 		});
 
+		const colCount = Math.max(...config.rows.map((r) => r.length));
+		const colWidths: number[] = [];
+		for (let x = 0; x < colCount; x++) {
+			let w = 1;
+			config.rows.forEach((row) => {
+				const t = row[x];
+				if (t) {
+					w = Math.max(w, t.length);
+				}
+			});
+			colWidths[x] = w;
+		}
+
 		config.rows.forEach((row, y) => {
 			const grid = new ButtonGridController(doc, {
 				size: [row.length, 1],
-				cellConfig: (x) => ({title: row[x]}),
+				cellConfig: (x) => ({title: row[x] ?? ''}),
 			});
-			grid.view.element.style.gridTemplateColumns = `repeat(${row.length}, 2ch)`;
+			grid.view.element.style.gridTemplateColumns = row
+				.map((_, i) => `${colWidths[i]}ch`)
+				.join(' ');
 			grid.cellControllers.forEach((cc, x) => {
+				if (!row[x]) {
+					cc.viewProps.set('hidden', true);
+				}
 				this.coordMap_.set(cc, [x, y]);
 				this.cellControllers.push(cc);
 			});

--- a/src/element-picker/controller/element-picker.ts
+++ b/src/element-picker/controller/element-picker.ts
@@ -1,0 +1,52 @@
+import {
+	ButtonController,
+	Controller,
+	PlainView,
+	ViewProps,
+} from '@tweakpane/core';
+
+import {ButtonGridController} from '../../button-grid/controller/button-grid.js';
+
+export interface ElementPickerControllerConfig {
+	rows: string[][];
+}
+
+export class ElementPickerController implements Controller<PlainView> {
+	public readonly view: PlainView;
+	public readonly viewProps: ViewProps;
+	public readonly rowControllers: ButtonGridController[] = [];
+	public readonly cellControllers: ButtonController[] = [];
+	private coordMap_: Map<ButtonController, [number, number]> = new Map();
+
+	constructor(doc: Document, config: ElementPickerControllerConfig) {
+		this.viewProps = ViewProps.create();
+		this.view = new PlainView(doc, {
+			viewProps: this.viewProps,
+			viewName: 'elpick',
+		});
+
+		config.rows.forEach((row, y) => {
+			const grid = new ButtonGridController(doc, {
+				size: [row.length, 1],
+				cellConfig: (x) => ({title: row[x]}),
+			});
+			grid.view.element.style.gridTemplateColumns = `repeat(${row.length}, 2ch)`;
+			grid.cellControllers.forEach((cc, x) => {
+				this.coordMap_.set(cc, [x, y]);
+				this.cellControllers.push(cc);
+			});
+			this.rowControllers.push(grid);
+			this.view.element.appendChild(grid.view.element);
+		});
+
+		this.viewProps.handleDispose(() => {
+			this.rowControllers.forEach((rc) => {
+				rc.viewProps.set('disposed', true);
+			});
+		});
+	}
+
+	public cellCoord(cc: ButtonController): [number, number] | undefined {
+		return this.coordMap_.get(cc);
+	}
+}

--- a/src/element-picker/plugin.ts
+++ b/src/element-picker/plugin.ts
@@ -14,7 +14,7 @@ import {ElementPickerBladeController} from './controller/element-picker-blade.js
 export interface ElementPickerBladeParams extends BaseBladeParams {
 	view: 'elementpicker';
 	label?: string;
-	rows?: number;
+	mode?: 'full' | 'compact';
 }
 
 const FULL_TABLE: (string | null)[][] = [
@@ -80,21 +80,19 @@ const FULL_TABLE: (string | null)[][] = [
 	],
 ];
 
-const COMPACT_TABLE: string[][] = [
-	['H', 'He'],
-	['Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne'],
-];
-
 const SKIP_START = 2;
 const SKIP_END = 11;
 
-function buildRows(rowCount: number): string[][] {
-	if (rowCount <= 2) {
-		return COMPACT_TABLE.slice(0, rowCount).map((r) => r.slice());
+function getTable(mode: 'full' | 'compact'): (string | null)[][] {
+	if (mode === 'full') {
+		return FULL_TABLE;
+	} else if (mode === 'compact') {
+		return FULL_TABLE.slice(0, 2).map((row) =>
+			row.map((el, i) => (i < SKIP_START || i > SKIP_END ? null : el)),
+		);
+	} else {
+		throw new Error(`Unknown mode: ${mode}`);
 	}
-	return FULL_TABLE.slice(0, rowCount).map((row) =>
-		row.filter((_, i) => i < SKIP_START || i > SKIP_END).map((v) => v ?? ''),
-	);
 }
 
 export const ElementPickerBladePlugin: BladePlugin<ElementPickerBladeParams> =
@@ -111,10 +109,10 @@ export const ElementPickerBladePlugin: BladePlugin<ElementPickerBladeParams> =
 			return result ? {params: result} : null;
 		},
 		controller(args) {
-			const rows = Math.max(1, Math.min(3, args.params.rows ?? 3));
-			const data = buildRows(rows);
+			const mode = args.params.mode ?? 'full';
+			const table = getTable(mode);
 			const picker = new ElementPickerController(args.document, {
-				rows: data,
+				table: table,
 			});
 			return new ElementPickerBladeController(args.document, {
 				blade: args.blade,

--- a/src/element-picker/plugin.ts
+++ b/src/element-picker/plugin.ts
@@ -1,0 +1,122 @@
+import {
+	BaseBladeParams,
+	BladePlugin,
+	createPlugin,
+	LabelPropsObject,
+	parseRecord,
+	ValueMap,
+} from '@tweakpane/core';
+
+import {ButtonGridApi} from '../button-grid/api/button-grid.js';
+import {ButtonGridController} from '../button-grid/controller/button-grid.js';
+import {ButtonGridBladeController} from '../button-grid/controller/button-grid-blade.js';
+
+export interface ElementPickerBladeParams extends BaseBladeParams {
+	view: 'elementpicker';
+	label?: string;
+}
+
+const ELEMENTS: (string | null)[][] = [
+	[
+		'H',
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		'He',
+	],
+	[
+		'Li',
+		'Be',
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		'B',
+		'C',
+		'N',
+		'O',
+		'F',
+		'Ne',
+	],
+	[
+		'Na',
+		'Mg',
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		'Al',
+		'Si',
+		'P',
+		'S',
+		'Cl',
+		'Ar',
+	],
+];
+
+export const ElementPickerBladePlugin: BladePlugin<ElementPickerBladeParams> =
+	createPlugin({
+		id: 'elementpicker',
+		type: 'blade',
+
+		accept(params) {
+			const result = parseRecord<ElementPickerBladeParams>(params, (p) => ({
+				view: p.required.constant('elementpicker'),
+				label: p.optional.string,
+			}));
+			return result ? {params: result} : null;
+		},
+		controller(args) {
+			const grid = new ButtonGridController(args.document, {
+				size: [18, 3],
+				cellConfig: (x, y) => ({
+					title: ELEMENTS[y][x] ?? '',
+				}),
+			});
+			grid.cellControllers.forEach((cc, i) => {
+				const x = i % 18;
+				const y = Math.floor(i / 18);
+				if (!ELEMENTS[y][x]) {
+					cc.viewProps.set('disabled', true);
+				}
+			});
+			return new ButtonGridBladeController(args.document, {
+				blade: args.blade,
+				labelProps: ValueMap.fromObject<LabelPropsObject>({
+					label: args.params.label,
+				}),
+				valueController: grid,
+			});
+		},
+		api(args) {
+			if (args.controller instanceof ButtonGridBladeController) {
+				return new ButtonGridApi(args.controller);
+			}
+			return null;
+		},
+	});

--- a/src/element-picker/plugin.ts
+++ b/src/element-picker/plugin.ts
@@ -85,11 +85,16 @@ const COMPACT_TABLE: string[][] = [
 	['Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne'],
 ];
 
+const SKIP_START = 2;
+const SKIP_END = 11;
+
 function buildRows(rowCount: number): string[][] {
 	if (rowCount <= 2) {
 		return COMPACT_TABLE.slice(0, rowCount).map((r) => r.slice());
 	}
-	return FULL_TABLE.slice(0, rowCount).map((r) => r.map((v) => v ?? ''));
+	return FULL_TABLE.slice(0, rowCount).map((row) =>
+		row.filter((_, i) => i < SKIP_START || i > SKIP_END).map((v) => v ?? ''),
+	);
 }
 
 export const ElementPickerBladePlugin: BladePlugin<ElementPickerBladeParams> =

--- a/src/element-picker/plugin.ts
+++ b/src/element-picker/plugin.ts
@@ -92,19 +92,40 @@ export const ElementPickerBladePlugin: BladePlugin<ElementPickerBladeParams> =
 			return result ? {params: result} : null;
 		},
 		controller(args) {
+			const cols = 18;
+			const rows = 3;
 			const grid = new ButtonGridController(args.document, {
-				size: [18, 3],
+				size: [cols, rows],
 				cellConfig: (x, y) => ({
 					title: ELEMENTS[y][x] ?? '',
 				}),
 			});
+
+			// Hide buttons for empty cells
 			grid.cellControllers.forEach((cc, i) => {
-				const x = i % 18;
-				const y = Math.floor(i / 18);
+				const x = i % cols;
+				const y = Math.floor(i / cols);
 				if (!ELEMENTS[y][x]) {
 					cc.viewProps.set('disabled', true);
+					cc.view.element.style.visibility = 'hidden';
 				}
 			});
+
+			// Adjust column widths based on text length
+			const colWidths = [] as number[];
+			for (let x = 0; x < cols; x++) {
+				let maxLen = 0;
+				for (let y = 0; y < rows; y++) {
+					const sym = ELEMENTS[y][x];
+					if (sym) {
+						maxLen = Math.max(maxLen, sym.length);
+					}
+				}
+				colWidths.push(Math.max(1, maxLen));
+			}
+			grid.view.element.style.gridTemplateColumns = colWidths
+				.map((l) => `${l}fr`)
+				.join(' ');
 			return new ButtonGridBladeController(args.document, {
 				blade: args.blade,
 				labelProps: ValueMap.fromObject<LabelPropsObject>({

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,4 +59,6 @@ export * from './radio-grid/controller/radio.js';
 export * from './radio-grid/controller/radio-grid.js';
 export * from './radio-grid/view/radio.js';
 
+export * from './element-picker/api/element-picker.js';
+export * from './element-picker/controller/element-picker.js';
 export * from './element-picker/plugin.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import {TpPlugin} from '@tweakpane/core';
 
 import {ButtonGridBladePlugin} from './button-grid/plugin.js';
 import {CubicBezierBladePlugin} from './cubic-bezier/plugin.js';
+import {ElementPickerBladePlugin} from './element-picker/plugin.js';
 import {FpsGraphBladePlugin} from './fps-graph/plugin.js';
 import {IntervalInputPlugin} from './interval/plugin.js';
 import {RadioGridBladePlugin} from './radio-grid/blade-plugin.js';
@@ -22,6 +23,7 @@ export const plugins: TpPlugin[] = [
 	RadioGruidBooleanInputPlugin,
 	RadioGruidNumberInputPlugin,
 	RadioGruidStringInputPlugin,
+	ElementPickerBladePlugin,
 ];
 
 export * from './button-grid/api/button-cell.js';
@@ -56,3 +58,5 @@ export * from './radio-grid/api/tp-radio-grid-event.js';
 export * from './radio-grid/controller/radio.js';
 export * from './radio-grid/controller/radio-grid.js';
 export * from './radio-grid/view/radio.js';
+
+export * from './element-picker/plugin.js';

--- a/src/sass/_element-picker.scss
+++ b/src/sass/_element-picker.scss
@@ -1,0 +1,7 @@
+@use '../../node_modules/@tweakpane/core/lib/sass/tp';
+
+.#{tp.$prefix}-elpickv {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}

--- a/src/sass/plugin.scss
+++ b/src/sass/plugin.scss
@@ -4,3 +4,4 @@
 @use './interval';
 @use './radio';
 @use './radio-grid';
+@use './element-picker';

--- a/test/browser.html
+++ b/test/browser.html
@@ -100,20 +100,27 @@
 			console.log(ev);
 		});
 
-		panes[1].addBlade({
-			view: 'buttongrid',
-			size: [3, 3],
-			cells: (x, y) => ({
-				title: [
-					['NW', 'N', 'NE'],
-					['W',  '*', 'E'],
-					['SW', 'S', 'SE'],
-				][y][x],
-			}),
-			label: 'button\ngrid',
-		}).on('click', (ev) => {
-			console.log(ev);
-		});
+                panes[1].addBlade({
+                        view: 'buttongrid',
+                        size: [3, 3],
+                        cells: (x, y) => ({
+                                title: [
+                                        ['NW', 'N', 'NE'],
+                                        ['W',  '*', 'E'],
+                                        ['SW', 'S', 'SE'],
+                                ][y][x],
+                        }),
+                        label: 'button\ngrid',
+                }).on('click', (ev) => {
+                        console.log(ev);
+                });
+
+                panes[1].addBlade({
+                        view: 'elementpicker',
+                        label: 'elements',
+                }).on('click', (ev) => {
+                        console.log(ev);
+                });
 
 		window.panes = panes;
 

--- a/test/browser.html
+++ b/test/browser.html
@@ -1,145 +1,152 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-	<meta charset="UTF-8">
-	<title></title>
-	<style>
-		body {
-			margin: 0;
-		}
-		.wrapper {
-			align-items: start;
-			background-color: #f1f2f3;
-			box-sizing: border-box;
-			display: grid;
-			gap: 32px;
-			grid-template-columns: repeat(auto-fit, 256px);
-			justify-content: center;
-			margin-left: auto;
-			margin-right: auto;
-			margin-top: 32px;
-			max-width: 960px;
-			padding: 64px;
-		}
-	</style>
-</head>
-<body>
-	<div class="wrapper">
-	</div>
-	<script type="module">
-		import {Pane} from '../node_modules/tweakpane/dist/tweakpane.js';
-		import * as TweakpaneEssentialsPlugin from '../dist/tweakpane-plugin-essentials.js';
+	<head>
+		<meta charset="UTF-8" />
+		<title></title>
+		<style>
+			body {
+				margin: 0;
+			}
+			.wrapper {
+				align-items: start;
+				background-color: #f1f2f3;
+				box-sizing: border-box;
+				display: grid;
+				gap: 32px;
+				grid-template-columns: repeat(auto-fit, 256px);
+				justify-content: center;
+				margin-left: auto;
+				margin-right: auto;
+				margin-top: 32px;
+				max-width: 960px;
+				padding: 64px;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="wrapper"></div>
+		<script type="module">
+			import {Pane} from '../node_modules/tweakpane/dist/tweakpane.js';
+			import * as TweakpaneEssentialsPlugin from '../dist/tweakpane-plugin-essentials.js';
 
-		const params = {
-			interval: {min: 40, max: 60},
-			radiogrid: 25,
-		};
-               const panes = [
-                       'Input bindings',
-                       'Blades',
-                       'Element Picker',
-               ].map((title) => {
-			const pane = new Pane({
-				container: document.querySelector('.wrapper'),
-				title: title,
-			});
-
-			// Register plugin
-			pane.registerPlugin(TweakpaneEssentialsPlugin);
-
-			return pane;
-		});
-
-		// Input bindings
-		panes[0].addBinding(params, 'interval', {
-			format: (v) => v.toFixed(1),
-			min: 20,
-			max: 80,
-		}).on('change', (ev) => {
-			console.log(ev);
-		});
-
-		const scales = [10, 20, 25, 50, 75, 100];
-		panes[0].addBinding(params, 'radiogrid', {
-			view: 'radiogrid',
-			groupName: 'scale',
-			size: [3, 2],
-			cells: (x, y) => ({
-				title: `${scales[y * 3 + x]}%`,
-				value: scales[y * 3 + x],
-			}),
-			label: 'radiogrid',
-		}).on('change', (ev) => {
-			console.log(ev);
-		});
-
-		// Blades
-		const fpsGraph = panes[1].addBlade({
-			view: 'fpsgraph',
-
-			label: 'fpsgraph',
-			rows: 2,
-		});
-		function render() {
-			fpsGraph.begin();
-
-			// Rendering
-
-			fpsGraph.end();
-			requestAnimationFrame(render);
-		}
-		render();
-
-		panes[1].addBlade({
-			view: 'cubicbezier',
-			value: [0.5, 0, 0.5, 1],
-
-			expanded: true,
-			label: 'cubic\nbezier',
-			picker: 'inline',
-		}).on('change', (ev) => {
-			console.log(ev);
-		});
-
-                panes[1].addBlade({
-                        view: 'buttongrid',
-                        size: [3, 3],
-                        cells: (x, y) => ({
-                                title: [
-                                        ['NW', 'N', 'NE'],
-                                        ['W',  '*', 'E'],
-                                        ['SW', 'S', 'SE'],
-                                ][y][x],
-                        }),
-                        label: 'button\ngrid',
-                }).on('click', (ev) => {
-                        console.log(ev);
-                });
-
-               panes[2].addBlade({
-                       view: 'elementpicker',
-                       label: 'elements',
-               }).on('click', (ev) => {
-                       console.log(ev);
-               });
-
-		window.panes = panes;
-
-		if (location.search === '?readme') {
-			panes.forEach((pane) => {
-				pane.children.forEach((child) => {
-					const wrapperElem = document.createElement('div');
-					wrapperElem.classList.add('wrapper');
-					document.body.appendChild(wrapperElem);
-
-					const newPane = new Pane({
-						container: wrapperElem,
+			const params = {
+				interval: {min: 40, max: 60},
+				radiogrid: 25,
+			};
+			const panes = ['Input bindings', 'Blades', 'Element Picker'].map(
+				(title) => {
+					const pane = new Pane({
+						container: document.querySelector('.wrapper'),
+						title: title,
 					});
-					newPane.registerPlugin(TweakpaneEssentialsPlugin);
-					newPane.add(child);
+
+					// Register plugin
+					pane.registerPlugin(TweakpaneEssentialsPlugin);
+
+					return pane;
+				},
+			);
+
+			// Input bindings
+			panes[0]
+				.addBinding(params, 'interval', {
+					format: (v) => v.toFixed(1),
+					min: 20,
+					max: 80,
+				})
+				.on('change', (ev) => {
+					console.log(ev);
 				});
+
+			const scales = [10, 20, 25, 50, 75, 100];
+			panes[0]
+				.addBinding(params, 'radiogrid', {
+					view: 'radiogrid',
+					groupName: 'scale',
+					size: [3, 2],
+					cells: (x, y) => ({
+						title: `${scales[y * 3 + x]}%`,
+						value: scales[y * 3 + x],
+					}),
+					label: 'radiogrid',
+				})
+				.on('change', (ev) => {
+					console.log(ev);
+				});
+
+			// Blades
+			const fpsGraph = panes[1].addBlade({
+				view: 'fpsgraph',
+
+				label: 'fpsgraph',
+				rows: 2,
 			});
-		}
-	</script>
-</body>
+			function render() {
+				fpsGraph.begin();
+
+				// Rendering
+
+				fpsGraph.end();
+				requestAnimationFrame(render);
+			}
+			render();
+
+			panes[1]
+				.addBlade({
+					view: 'cubicbezier',
+					value: [0.5, 0, 0.5, 1],
+
+					expanded: true,
+					label: 'cubic\nbezier',
+					picker: 'inline',
+				})
+				.on('change', (ev) => {
+					console.log(ev);
+				});
+
+			panes[1]
+				.addBlade({
+					view: 'buttongrid',
+					size: [3, 3],
+					cells: (x, y) => ({
+						title: [
+							['NW', 'N', 'NE'],
+							['W', '*', 'E'],
+							['SW', 'S', 'SE'],
+						][y][x],
+					}),
+					label: 'button\ngrid',
+				})
+				.on('click', (ev) => {
+					console.log(ev);
+				});
+
+			panes[2]
+				.addBlade({
+					view: 'elementpicker',
+					rows: 2,
+				})
+				.on('click', (ev) => {
+					console.log(ev);
+				});
+
+			window.panes = panes;
+
+			if (location.search === '?readme') {
+				panes.forEach((pane) => {
+					pane.children.forEach((child) => {
+						const wrapperElem = document.createElement('div');
+						wrapperElem.classList.add('wrapper');
+						document.body.appendChild(wrapperElem);
+
+						const newPane = new Pane({
+							container: wrapperElem,
+						});
+						newPane.registerPlugin(TweakpaneEssentialsPlugin);
+						newPane.add(child);
+					});
+				});
+			}
+		</script>
+	</body>
 </html>

--- a/test/browser.html
+++ b/test/browser.html
@@ -34,10 +34,11 @@
 			interval: {min: 40, max: 60},
 			radiogrid: 25,
 		};
-		const panes = [
-			'Input bindings',
-			'Blades',
-		].map((title) => {
+               const panes = [
+                       'Input bindings',
+                       'Blades',
+                       'Element Picker',
+               ].map((title) => {
 			const pane = new Pane({
 				container: document.querySelector('.wrapper'),
 				title: title,
@@ -115,12 +116,12 @@
                         console.log(ev);
                 });
 
-                panes[1].addBlade({
-                        view: 'elementpicker',
-                        label: 'elements',
-                }).on('click', (ev) => {
-                        console.log(ev);
-                });
+               panes[2].addBlade({
+                       view: 'elementpicker',
+                       label: 'elements',
+               }).on('click', (ev) => {
+                       console.log(ev);
+               });
 
 		window.panes = panes;
 

--- a/test/browser.html
+++ b/test/browser.html
@@ -124,7 +124,7 @@
 			panes[2]
 				.addBlade({
 					view: 'elementpicker',
-					rows: 2,
+					model: "compact",
 				})
 				.on('click', (ev) => {
 					console.log(ev);


### PR DESCRIPTION
Hi, I want to implement a new plugin called Element picker.

User can use this picker to choose what element they want, then they can draw specific atoms on canvas.

The final should look like this:

<img width="490" alt="image" src="https://github.com/user-attachments/assets/af6f79f3-d5b4-4694-91ec-8b33b662c5ba" />

But I want to make some improvement. First, I want two modes, first one is compact, which only display first two rows, another is full. Second, I hope use can add some extra slots in the black, instead of a legend on top.

I mimic ButtonGrid to create a framework of element-picker, but I cant solve this:

I use a two dimension array to describe periodic table. When it comes to null, the Button should invisible and disable, but still here like a placeholder. I dont know how to implement this effect, so all buttons are squeshed.

Do you think it's a good feature, can you please help me finish this?

I really like this elegant proejct, I want to contribute more plugins here!

Thanks